### PR TITLE
Add support for M1 Macs

### DIFF
--- a/src/leiningen/protoc.clj
+++ b/src/leiningen/protoc.clj
@@ -187,13 +187,15 @@
 
 (defn get-os
   []
-  (let [os (leiningen.core.utils/get-os)]
-    (name (if (= os :macosx) :osx os))))
+  (if-let [os (leiningen.core.utils/get-os)]
+    (name (if (= os :macosx) :osx os))
+    (throw (Exception. "Leiningen failed to identify the OS"))))
 
 (defn get-arch
   []
-  (let [arch (leiningen.core.utils/get-arch)]
-    (name (if (= arch :x86) :x86_32 arch))))
+  (if-let [arch (leiningen.core.utils/get-arch)]
+    (name (if (= arch :x86) :x86_32 arch))
+    (throw (Exception. "Leiningen failed to detect the processor architecture"))))
 
 (defn resolve!
   "Resolves the Google Protocol Buffers code generation artifact+version in the


### PR DESCRIPTION
Versions of `com.google.protobuf/protoc` prior to 3.17.3 don't ship binaries suitable for Apple Arm chips. Those machines can run the `x86_64` versions of protoc, so for versions before 3.17.3 we choose that architecture instead.

Also, improve the error messages for when lein-protoc is used on an unsupported OS or architecture.